### PR TITLE
Use logger for SecurityConfig

### DIFF
--- a/core/src/main/java/com/fitness/core/config/SecurityConfig.java
+++ b/core/src/main/java/com/fitness/core/config/SecurityConfig.java
@@ -3,13 +3,15 @@ package com.fitness.core.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Configuration
 public class SecurityConfig {
 
   @Bean
   public BCryptPasswordEncoder passwordEncoder() {
-    System.out.println(">> Creating BCryptPasswordEncoder bean from SecurityConfig (core module)");
+    log.debug("Creating BCryptPasswordEncoder bean from SecurityConfig (core module)");
     return new BCryptPasswordEncoder();
   }
 }


### PR DESCRIPTION
## Summary
- switch SecurityConfig to use a logger instead of System.out.println

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684fe82f60508325bea589738f783c9b