### PR TITLE
Enable test context loading

### DIFF
--- a/activityservice/src/test/java/com/fitness/activityservice/ActivityserviceApplicationTests.java
+++ b/activityservice/src/test/java/com/fitness/activityservice/ActivityserviceApplicationTests.java
@@ -1,12 +1,21 @@
 package com.fitness.activityservice;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class ActivityserviceApplicationTests {
 
-  // @Test
-  // void contextLoads() {
-  // }
+  @Autowired
+  private ApplicationContext context;
+
+  @Test
+  void contextLoads() {
+    assertThat(context).isNotNull();
+  }
 
 }

--- a/userservice/src/test/java/com/fitness/userservice/UserserviceApplicationTests.java
+++ b/userservice/src/test/java/com/fitness/userservice/UserserviceApplicationTests.java
@@ -1,12 +1,21 @@
 package com.fitness.userservice;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class UserserviceApplicationTests {
 
-  // @Test
-  // void contextLoads() {
-  // }
+  @Autowired
+  private ApplicationContext context;
+
+  @Test
+  void contextLoads() {
+    assertThat(context).isNotNull();
+  }
 
 }


### PR DESCRIPTION
## Summary
- uncomment and expand UserserviceApplicationTests
- uncomment and expand ActivityserviceApplicationTests

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe8de41dc8325b3095fdac7fc41c1