### PR TITLE
Remove Java 24 override

### DIFF
--- a/activityservice/pom.xml
+++ b/activityservice/pom.xml
@@ -26,9 +26,6 @@
     <tag/>
     <url/>
   </scm>
-  <properties>
-    <java.version>24</java.version>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>jakarta.validation</groupId>


### PR DESCRIPTION
## Summary
- inherit parent Java version in `activityservice`

## Testing
- `./activityservice/mvnw -q -pl activityservice -am test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/...)*

------
https://chatgpt.com/codex/tasks/task_e_684fe9f4f0d08325b6ff1da5cd025d4e