### PR TITLE
Remove password from user responses

### DIFF
--- a/userservice/src/main/java/com/fitness/userservice/dto/UserResponse.java
+++ b/userservice/src/main/java/com/fitness/userservice/dto/UserResponse.java
@@ -11,7 +11,6 @@ import lombok.Data;
 public class UserResponse {
     private String id;
     private String email;
-    private String password;
     private String firstName;
     private String lastName;
     private UserRole role = UserRole.USER;
@@ -30,7 +29,6 @@ public class UserResponse {
         // Copy the properties from the User to the UserResponse
         response.setId(user.getId());
         response.setEmail(user.getEmail());
-        response.setPassword(user.getPassword());
         response.setFirstName(user.getFirstName());
         response.setLastName(user.getLastName());
         response.setRole(user.getRole());


### PR DESCRIPTION
## Summary
- remove the password field from `UserResponse`
- stop populating password in the `from(User)` factory method

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe7b08a688325a2fa7b9771b25db8